### PR TITLE
AC1: Unified notification schema

### DIFF
--- a/schema/examples/iot-message.json
+++ b/schema/examples/iot-message.json
@@ -1,0 +1,13 @@
+{
+  "id": "iot-doorbell-1717171600",
+  "source": "iot",
+  "sender": "Front Door",
+  "channel": "doorbell",
+  "preview": "Motion detected at front door.",
+  "timestamp": "2026-05-31T05:46:40Z",
+  "priority": 2,
+  "metadata": {
+    "platformMessageId": "1717171600",
+    "workspaceOrTenant": "home"
+  }
+}

--- a/schema/examples/messenger-message.json
+++ b/schema/examples/messenger-message.json
@@ -1,0 +1,13 @@
+{
+  "id": "messenger-12345678901234567",
+  "source": "messenger",
+  "sender": "John Doe",
+  "channel": "John Doe",
+  "preview": "Hey are you free tonight?",
+  "timestamp": "2026-05-31T05:50:00Z",
+  "priority": 1,
+  "metadata": {
+    "platformMessageId": "12345678901234567",
+    "threadId": "t_67890"
+  }
+}

--- a/schema/examples/slack-message.json
+++ b/schema/examples/slack-message.json
@@ -1,0 +1,14 @@
+{
+  "id": "slack-C04AB1234-1717171717.123456",
+  "source": "slack",
+  "sender": "jackylui",
+  "channel": "#alerts",
+  "preview": "Deploy to production is live. All checks passed.",
+  "timestamp": "2026-05-31T06:32:00Z",
+  "priority": 3,
+  "metadata": {
+    "platformMessageId": "1717171717.123456",
+    "threadId": null,
+    "workspaceOrTenant": "my-workspace"
+  }
+}

--- a/schema/examples/teams-message.json
+++ b/schema/examples/teams-message.json
@@ -1,0 +1,14 @@
+{
+  "id": "teams-19:abc123@thread.v2-1717171800000",
+  "source": "teams",
+  "sender": "Bob Smith",
+  "channel": "General",
+  "preview": "Standup moved to 3pm today, same link.",
+  "timestamp": "2026-05-31T06:30:00Z",
+  "priority": 1,
+  "metadata": {
+    "platformMessageId": "1717171800000",
+    "threadId": "19:abc123@thread.v2",
+    "workspaceOrTenant": "mycompany.onmicrosoft.com"
+  }
+}

--- a/schema/notification-batch.schema.json
+++ b/schema/notification-batch.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "weatherbox-notification-batch",
+  "title": "WeatherBox Notification Batch",
+  "description": "Batch envelope sent over MQTT and Serial UART to the ESP32/Mega. Entire serialised payload must fit in 6000 bytes (Mega Serial buffer limit).",
+  "type": "object",
+  "required": ["notifications"],
+  "properties": {
+    "notifications": {
+      "type": "array",
+      "maxItems": 8,
+      "items": { "$ref": "notification.schema.json" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schema/notification.schema.json
+++ b/schema/notification.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "weatherbox-notification",
+  "title": "WeatherBox Notification",
+  "description": "Unified notification schema used across MQTT, Serial UART, and WebSocket layers",
+  "type": "object",
+  "required": ["id", "source", "sender", "channel", "preview", "timestamp", "priority"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique notification ID (used for deduplication). Format: <source>-<platform-message-id>"
+    },
+    "source": {
+      "type": "string",
+      "enum": ["slack", "teams", "messenger", "iot"],
+      "description": "Origin platform of the notification"
+    },
+    "sender": {
+      "type": "string",
+      "maxLength": 32,
+      "description": "Display name of the person or system that sent the message"
+    },
+    "channel": {
+      "type": "string",
+      "maxLength": 32,
+      "description": "Channel, conversation, or topic name"
+    },
+    "preview": {
+      "type": "string",
+      "maxLength": 120,
+      "description": "Truncated message body shown on TFT and feed UI"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp when the message was originally sent"
+    },
+    "priority": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 3,
+      "description": "0=low (dimmed), 1=normal, 2=elevated, 3=urgent (yellow highlight on TFT)"
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional platform-specific fields. Not displayed on TFT; available to rules engine and feed UI.",
+      "properties": {
+        "platformMessageId": { "type": "string" },
+        "threadId": { "type": "string" },
+        "workspaceOrTenant": { "type": "string" },
+        "avatarUrl": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- Defines the JSON contract used across all layers (MQTT, Serial UART, WebSocket, browser feed UI)
- Single `notification.schema.json` with fields: `id`, `source`, `sender`, `channel`, `preview`, `timestamp`, `priority`, `metadata`
- `notification-batch.schema.json` wraps up to 8 notifications — sized to fit the Mega's 6,000-byte Serial buffer
- Example JSON for each source: Slack, MS Teams, Facebook Messenger, IoT

## Why this comes first
Every subsequent PR (server, ESP32, Mega display) references this schema. Getting it agreed on here avoids drift between layers.

## Test plan
- [ ] Review field names and types match what Slack/Teams/Messenger APIs actually return (platform integrations will adapt to this contract)
- [ ] Confirm `maxItems: 8` + `preview: 120 chars` comfortably fits 6,000 bytes when serialised
- [ ] Confirm `priority` levels (0–3) match the display behaviour you want on the TFT

🤖 Generated with [Claude Code](https://claude.com/claude-code)