### PR TITLE
AC2: Node.js server scaffold

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,37 @@
+# ── Server ────────────────────────────────────────────────────────────────────
+PORT=3000
+
+# ── AWS IoT MQTT ───────────────────────────────────────────────────────────────
+# Endpoint from: AWS Console → IoT Core → Settings → Device data endpoint
+AWS_IOT_ENDPOINT=xxxxxxxxxxxx-ats.iot.ap-southeast-2.amazonaws.com
+AWS_IOT_TOPIC_PUBLISH=weatherbox/notifications
+# Paths to the certificates downloaded when you created the IoT Thing
+AWS_IOT_CERT_PATH=./certs/device.pem.crt
+AWS_IOT_KEY_PATH=./certs/private.pem.key
+AWS_IOT_CA_PATH=./certs/AmazonRootCA1.pem
+
+# ── Slack ──────────────────────────────────────────────────────────────────────
+# Bot User OAuth Token — from your Slack App → OAuth & Permissions
+SLACK_BOT_TOKEN=xoxb-
+# Signing Secret — from your Slack App → Basic Information
+SLACK_SIGNING_SECRET=
+
+# ── Microsoft Teams (Azure AD app registration) ────────────────────────────────
+# From Azure Portal → App registrations → your app
+TEAMS_TENANT_ID=
+TEAMS_CLIENT_ID=
+TEAMS_CLIENT_SECRET=
+# Redirect URI registered in Azure AD (must match exactly)
+TEAMS_REDIRECT_URI=https://your-tunnel.trycloudflare.com/auth/teams/callback
+
+# ── Facebook Messenger ─────────────────────────────────────────────────────────
+# From Meta for Developers → your app → Messenger → Settings
+MESSENGER_APP_ID=
+MESSENGER_APP_SECRET=
+MESSENGER_VERIFY_TOKEN=choose-any-random-string-here
+# Redirect URI registered in your Meta app
+MESSENGER_REDIRECT_URI=https://your-tunnel.trycloudflare.com/auth/messenger/callback
+
+# ── Session ────────────────────────────────────────────────────────────────────
+# Any long random string — used to sign the OAuth state parameter
+SESSION_SECRET=change-me-to-something-random

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+.tokens.json
+certs/

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,190 @@
+# WeatherBox Server
+
+Node.js bridge that receives webhooks from Slack, MS Teams, and Facebook Messenger, applies notification rules, and forwards messages to the ESP32 via AWS IoT MQTT.
+
+---
+
+## Prerequisites
+
+- Node.js 18+
+- A Raspberry Pi (or any always-on Linux machine) on your local network
+- AWS IoT Thing certificates (already in your project's `cdk/` stack)
+
+---
+
+## Setup
+
+### 1. Install dependencies
+
+```bash
+cd server
+npm install
+```
+
+### 2. Configure environment
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and fill in every value. See the per-platform sections below for where to find each credential.
+
+### 3. Add AWS IoT certificates
+
+Create a `server/certs/` directory (gitignored) and copy the three certificate files downloaded when you created your IoT Thing:
+
+```
+server/certs/
+  AmazonRootCA1.pem
+  device.pem.crt
+  private.pem.key
+```
+
+Update the paths in `.env` if you put them elsewhere.
+
+### 4. Start the server
+
+```bash
+# Development (auto-restart on changes)
+npm run dev
+
+# Production
+npm start
+```
+
+The server starts on `http://localhost:3000`. Visit `/health` to confirm it's running.
+
+---
+
+## Exposing to the internet (required for webhooks)
+
+Slack, Teams, and Messenger all require a **public HTTPS URL** to deliver webhook events. The recommended approach for a Pi at home is **Cloudflare Tunnel** — free, no port forwarding, automatic HTTPS.
+
+### Cloudflare Tunnel setup
+
+**One-time install** (on the Pi):
+
+```bash
+# Download and install cloudflared
+curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64.deb -o cloudflared.deb
+sudo dpkg -i cloudflared.deb
+```
+
+**Start a temporary tunnel** (for testing — URL changes on each run):
+
+```bash
+cloudflared tunnel --url http://localhost:3000
+```
+
+Copy the `https://xxxx.trycloudflare.com` URL it prints — use this as your webhook base URL when registering with each platform.
+
+**Persistent tunnel** (recommended for production — same URL every time):
+
+1. Log in: `cloudflared tunnel login`
+2. Create a named tunnel: `cloudflared tunnel create weatherbox`
+3. Create `~/.cloudflared/config.yml`:
+   ```yaml
+   tunnel: weatherbox
+   credentials-file: /home/pi/.cloudflared/<tunnel-id>.json
+   ingress:
+     - hostname: weatherbox.yourdomain.com
+       service: http://localhost:3000
+     - service: http_status:404
+   ```
+4. Route DNS: `cloudflared tunnel route dns weatherbox weatherbox.yourdomain.com`
+5. Run: `cloudflared tunnel run weatherbox`
+
+Your webhook base URL will be `https://weatherbox.yourdomain.com`.
+
+---
+
+## Running as a systemd service (auto-start on boot)
+
+Create `/etc/systemd/system/weatherbox.service`:
+
+```ini
+[Unit]
+Description=WeatherBox notification bridge
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/WeatherBox/server
+ExecStart=/usr/bin/node src/index.js
+Restart=on-failure
+RestartSec=5
+EnvironmentFile=/home/pi/WeatherBox/server/.env
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable weatherbox
+sudo systemctl start weatherbox
+sudo systemctl status weatherbox
+```
+
+Do the same for the Cloudflare tunnel if you want it to auto-start too:
+
+```bash
+sudo cloudflared service install
+sudo systemctl enable cloudflared
+sudo systemctl start cloudflared
+```
+
+---
+
+## Platform setup guides
+
+### Slack
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → **From scratch**
+2. Name it (e.g. "WeatherBox"), pick your workspace
+3. **OAuth & Permissions** → Scopes → Bot Token Scopes → add:
+   - `channels:history`, `channels:read`, `groups:history`, `im:history`
+4. **Install to Workspace** → copy the **Bot User OAuth Token** → set `SLACK_BOT_TOKEN` in `.env`
+5. **Basic Information** → App Credentials → copy **Signing Secret** → set `SLACK_SIGNING_SECRET`
+6. **Event Subscriptions** → Enable Events → Request URL: `https://your-tunnel/webhooks/slack`
+7. Subscribe to bot events: `message.channels`, `message.im`
+8. Reinstall the app when prompted
+
+### MS Teams
+
+1. Go to [portal.azure.com](https://portal.azure.com) → **Azure Active Directory** → **App registrations** → **New registration**
+2. Name it (e.g. "WeatherBox"), Supported account types: **Single tenant**
+3. Redirect URI: `https://your-tunnel/auth/teams/callback`
+4. Copy **Application (client) ID** → `TEAMS_CLIENT_ID`, **Directory (tenant) ID** → `TEAMS_TENANT_ID`
+5. **Certificates & secrets** → **New client secret** → copy value → `TEAMS_CLIENT_SECRET`
+6. **API permissions** → Add: `ChannelMessage.Read.All`, `Chat.Read` (Microsoft Graph, Delegated)
+7. Grant admin consent
+
+### Facebook Messenger
+
+1. Go to [developers.facebook.com](https://developers.facebook.com) → **My Apps** → **Create App** → **Business**
+2. Add **Messenger** product
+3. **Settings** → copy **App ID** → `MESSENGER_APP_ID`, **App Secret** → `MESSENGER_APP_SECRET`
+4. Choose a verify token (any string) → `MESSENGER_VERIFY_TOKEN`
+5. **Webhooks** → **Add Callback URL**: `https://your-tunnel/webhooks/messenger`, paste verify token
+6. Subscribe to: `messages`, `messaging_postbacks`
+7. Generate a **Page Access Token** for your page (used in the Messenger integration PR)
+
+---
+
+## Dashboard
+
+Once the server is running:
+
+| URL | Description |
+|-----|-------------|
+| `/health` | Server health check |
+| `/auth/status` | Which platforms are connected |
+| `/dashboard/rules` | Rules API (GET/POST) |
+| `/dashboard/feed` | Recent notifications (JSON) |
+
+Browser UI pages for rules management and live feed are added in later PRs (AC9, AC10).

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "weatherbox-server",
+  "version": "1.0.0",
+  "description": "WeatherBox notification bridge — receives webhooks from Slack/Teams/Messenger, applies rules, and publishes to ESP32 via AWS IoT MQTT.",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "mqtt": "^5.7.0",
+    "ws": "^8.17.1"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.4"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/server/rules.json
+++ b/server/rules.json
@@ -1,0 +1,12 @@
+{
+  "rules": [
+    { "source": "slack",     "channel": "alerts",   "priority": 3 },
+    { "source": "slack",     "priority": 1 },
+    { "source": "teams",     "channel": "General",  "priority": 1 },
+    { "source": "teams",     "priority": 1 },
+    { "source": "messenger", "priority": 1 },
+    { "source": "iot",       "priority": 2 }
+  ],
+  "maxMessages": 8,
+  "deduplicateWindowSeconds": 300
+}

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const path = require('path');
+
+const webhookRoutes = require('./routes/webhooks');
+const authRoutes = require('./routes/auth');
+const dashboardRoutes = require('./routes/dashboard');
+
+const app = express();
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(express.static(path.join(__dirname, '../public')));
+
+app.use('/webhooks', webhookRoutes);
+app.use('/auth', authRoutes);
+app.use('/dashboard', dashboardRoutes);
+
+app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+
+module.exports = app;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,0 +1,16 @@
+require('dotenv').config();
+const { createServer } = require('http');
+const app = require('./app');
+const { initMqtt } = require('./services/mqtt');
+const { attachWebSocket } = require('./services/websocket');
+
+const PORT = process.env.PORT || 3000;
+
+const httpServer = createServer(app);
+attachWebSocket(httpServer);
+
+httpServer.listen(PORT, () => {
+  console.log(`WeatherBox server running on http://localhost:${PORT}`);
+});
+
+initMqtt();

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -1,0 +1,25 @@
+const { Router } = require('express');
+const tokenStore = require('../services/tokenStore');
+
+const router = Router();
+
+// Connection status — used by the dashboard and by each platform's feature branch
+router.get('/status', (_req, res) => {
+  res.json({
+    slack: tokenStore.isConnected('slack'),
+    teams: tokenStore.isConnected('teams'),
+    messenger: tokenStore.isConnected('messenger'),
+  });
+});
+
+// Stubs — each platform's feature branch fills in the real OAuth flow
+router.get('/slack', (_req, res) => res.status(501).send('Slack OAuth not yet implemented'));
+router.get('/slack/callback', (_req, res) => res.status(501).send('Slack OAuth not yet implemented'));
+
+router.get('/teams', (_req, res) => res.status(501).send('Teams OAuth not yet implemented'));
+router.get('/teams/callback', (_req, res) => res.status(501).send('Teams OAuth not yet implemented'));
+
+router.get('/messenger', (_req, res) => res.status(501).send('Messenger OAuth not yet implemented'));
+router.get('/messenger/callback', (_req, res) => res.status(501).send('Messenger OAuth not yet implemented'));
+
+module.exports = router;

--- a/server/src/routes/dashboard.js
+++ b/server/src/routes/dashboard.js
@@ -1,0 +1,34 @@
+const { Router } = require('express');
+const store = require('../services/notificationStore');
+const rulesService = require('../services/rules');
+const tokenStore = require('../services/tokenStore');
+
+const router = Router();
+
+// Rules API — used by the rules dashboard UI (AC9)
+router.get('/rules', (_req, res) => {
+  res.json(rulesService.getRules());
+});
+
+router.post('/rules', (req, res) => {
+  const { rules, maxMessages, deduplicateWindowSeconds } = req.body;
+  if (!Array.isArray(rules)) return res.status(400).json({ error: 'rules must be an array' });
+  rulesService.save({ rules, maxMessages, deduplicateWindowSeconds });
+  res.json({ ok: true });
+});
+
+// Notification feed API — used by the live feed UI (AC10)
+router.get('/feed', (_req, res) => {
+  res.json(store.getAll());
+});
+
+// Auth status shortcut
+router.get('/status', (_req, res) => {
+  res.json({
+    slack: tokenStore.isConnected('slack'),
+    teams: tokenStore.isConnected('teams'),
+    messenger: tokenStore.isConnected('messenger'),
+  });
+});
+
+module.exports = router;

--- a/server/src/routes/webhooks.js
+++ b/server/src/routes/webhooks.js
@@ -1,0 +1,41 @@
+const { Router } = require('express');
+const store = require('../services/notificationStore');
+const rules = require('../services/rules');
+const { publishBatch } = require('../services/mqtt');
+const { broadcast } = require('../services/websocket');
+
+const router = Router();
+
+/**
+ * Central handler called by each platform's webhook route after it has
+ * parsed and normalised the payload into the unified Notification schema.
+ *
+ * @param {import('../services/notificationStore').Notification} notification
+ */
+function handleIncoming(notification) {
+  const match = rules.evaluate(notification);
+  if (!match) return; // dropped by rules engine
+
+  const enriched = { ...notification, priority: match.priority };
+  const accepted = store.add(enriched);
+  if (!accepted) return; // duplicate within dedupe window
+
+  broadcast(enriched);
+  publishBatch(store.getRecent(rules.getRules().maxMessages));
+}
+
+// Stubs — each platform's feature branch fills in the real implementation
+router.post('/slack', (req, res) => {
+  res.status(501).json({ error: 'Slack webhook not yet implemented' });
+});
+
+router.post('/teams', (req, res) => {
+  res.status(501).json({ error: 'Teams webhook not yet implemented' });
+});
+
+router.post('/messenger', (req, res) => {
+  res.status(501).json({ error: 'Messenger webhook not yet implemented' });
+});
+
+module.exports = router;
+module.exports.handleIncoming = handleIncoming;

--- a/server/src/services/mqtt.js
+++ b/server/src/services/mqtt.js
@@ -1,0 +1,52 @@
+const mqtt = require('mqtt');
+const fs = require('fs');
+
+let client = null;
+
+function initMqtt() {
+  const { AWS_IOT_ENDPOINT, AWS_IOT_CERT_PATH, AWS_IOT_KEY_PATH, AWS_IOT_CA_PATH } = process.env;
+
+  if (!AWS_IOT_ENDPOINT || !AWS_IOT_CERT_PATH) {
+    console.warn('AWS IoT credentials not configured — MQTT publisher disabled.');
+    return;
+  }
+
+  client = mqtt.connect(`mqtts://${AWS_IOT_ENDPOINT}`, {
+    cert: fs.readFileSync(AWS_IOT_CERT_PATH),
+    key: fs.readFileSync(AWS_IOT_KEY_PATH),
+    ca: fs.readFileSync(AWS_IOT_CA_PATH),
+    clientId: `weatherbox-server-${Date.now()}`,
+    reconnectPeriod: 5000,
+  });
+
+  client.on('connect', () => console.log('MQTT connected to AWS IoT'));
+  client.on('error', (err) => console.error('MQTT error:', err.message));
+  client.on('reconnect', () => console.log('MQTT reconnecting...'));
+}
+
+/**
+ * Publish a batch of notifications to the ESP32 via AWS IoT MQTT.
+ * Payload is serialised once here and must fit the Mega's 6000-byte Serial buffer.
+ * @param {import('./notificationStore').Notification[]} notifications
+ */
+function publishBatch(notifications) {
+  if (!client?.connected) {
+    console.warn('MQTT not connected — skipping publish');
+    return;
+  }
+
+  const topic = process.env.AWS_IOT_TOPIC_PUBLISH || 'weatherbox/notifications';
+  const payload = JSON.stringify({ notifications });
+
+  if (Buffer.byteLength(payload) > 6000) {
+    console.warn(`Batch payload ${Buffer.byteLength(payload)} bytes exceeds 6000-byte Mega buffer — truncating`);
+    // Trim from the end (lowest priority messages were appended last)
+    while (notifications.length > 1 && Buffer.byteLength(JSON.stringify({ notifications })) > 6000) {
+      notifications.pop();
+    }
+  }
+
+  client.publish(topic, JSON.stringify({ notifications }), { qos: 1 });
+}
+
+module.exports = { initMqtt, publishBatch };

--- a/server/src/services/notificationStore.js
+++ b/server/src/services/notificationStore.js
@@ -1,0 +1,58 @@
+/**
+ * @typedef {Object} Notification
+ * @property {string} id
+ * @property {'slack'|'teams'|'messenger'|'iot'} source
+ * @property {string} sender
+ * @property {string} channel
+ * @property {string} preview
+ * @property {string} timestamp
+ * @property {0|1|2|3} priority
+ * @property {Object} [metadata]
+ */
+
+const MAX_STORED = 50;
+const DEDUPE_WINDOW_MS = 5 * 60 * 1000;
+
+/** @type {Notification[]} */
+const store = [];
+const seenIds = new Map(); // id → timestamp (ms)
+
+/**
+ * Add a notification if it passes deduplication.
+ * Returns true if the notification was accepted, false if it was a duplicate.
+ * @param {Notification} notification
+ * @returns {boolean}
+ */
+function add(notification) {
+  const now = Date.now();
+
+  // Evict expired dedupe entries
+  for (const [id, ts] of seenIds) {
+    if (now - ts > DEDUPE_WINDOW_MS) seenIds.delete(id);
+  }
+
+  if (seenIds.has(notification.id)) return false;
+
+  seenIds.set(notification.id, now);
+  store.unshift(notification);
+  if (store.length > MAX_STORED) store.pop();
+  return true;
+}
+
+/**
+ * Return the N most recent notifications, sorted by priority desc then timestamp desc.
+ * @param {number} [limit=8]
+ * @returns {Notification[]}
+ */
+function getRecent(limit = 8) {
+  return [...store]
+    .sort((a, b) => b.priority - a.priority || new Date(b.timestamp) - new Date(a.timestamp))
+    .slice(0, limit);
+}
+
+/** @returns {Notification[]} */
+function getAll() {
+  return [...store];
+}
+
+module.exports = { add, getRecent, getAll };

--- a/server/src/services/rules.js
+++ b/server/src/services/rules.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const path = require('path');
+
+const RULES_PATH = path.join(__dirname, '../../rules.json');
+
+let rules = [];
+let maxMessages = 8;
+let deduplicateWindowSeconds = 300;
+
+function load() {
+  try {
+    const raw = JSON.parse(fs.readFileSync(RULES_PATH, 'utf8'));
+    rules = raw.rules || [];
+    maxMessages = raw.maxMessages ?? 8;
+    deduplicateWindowSeconds = raw.deduplicateWindowSeconds ?? 300;
+    console.log(`Rules loaded: ${rules.length} rule(s)`);
+  } catch (err) {
+    console.error('Failed to load rules.json — all messages will be dropped:', err.message);
+    rules = [];
+  }
+}
+
+function save(updated) {
+  fs.writeFileSync(RULES_PATH, JSON.stringify(updated, null, 2));
+  load();
+}
+
+function getRules() {
+  return { rules, maxMessages, deduplicateWindowSeconds };
+}
+
+/**
+ * Evaluate a notification against the loaded rules.
+ * Returns the matched rule (with priority applied) or null if no rule matches.
+ *
+ * Rule fields (all optional except source):
+ *   source       — 'slack' | 'teams' | 'messenger' | 'iot'
+ *   channel      — exact match on notification.channel (case-insensitive)
+ *   sender       — exact match on notification.sender (case-insensitive)
+ *   priority     — override priority to this value when rule matches
+ *
+ * Evaluation is top-down; first match wins.
+ *
+ * @param {import('./notificationStore').Notification} notification
+ * @returns {{ priority: number } | null}
+ */
+function evaluate(notification) {
+  for (const rule of rules) {
+    if (rule.source && rule.source !== notification.source) continue;
+    if (rule.channel && rule.channel.toLowerCase() !== notification.channel.toLowerCase()) continue;
+    if (rule.sender && rule.sender.toLowerCase() !== notification.sender.toLowerCase()) continue;
+    return { priority: rule.priority ?? notification.priority };
+  }
+  return null;
+}
+
+// Watch rules.json for changes so edits via the dashboard take effect immediately
+fs.watchFile(RULES_PATH, { interval: 1000 }, () => {
+  console.log('rules.json changed — reloading');
+  load();
+});
+
+load();
+
+module.exports = { load, save, getRules, evaluate };

--- a/server/src/services/tokenStore.js
+++ b/server/src/services/tokenStore.js
@@ -1,0 +1,34 @@
+/**
+ * Persists OAuth tokens to .tokens.json (gitignored).
+ * Each platform stores whatever fields its OAuth response returns.
+ * The file is read/written synchronously on startup and after each OAuth completion.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const TOKEN_PATH = path.join(__dirname, '../../.tokens.json');
+
+function load() {
+  try {
+    return JSON.parse(fs.readFileSync(TOKEN_PATH, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function save(platform, data) {
+  const all = load();
+  all[platform] = { ...data, savedAt: new Date().toISOString() };
+  fs.writeFileSync(TOKEN_PATH, JSON.stringify(all, null, 2));
+}
+
+function get(platform) {
+  return load()[platform] || null;
+}
+
+function isConnected(platform) {
+  const entry = get(platform);
+  return entry != null && (entry.accessToken || entry.botToken);
+}
+
+module.exports = { save, get, isConnected };

--- a/server/src/services/websocket.js
+++ b/server/src/services/websocket.js
@@ -1,0 +1,27 @@
+const { WebSocketServer } = require('ws');
+
+let wss = null;
+
+function attachWebSocket(httpServer) {
+  wss = new WebSocketServer({ server: httpServer, path: '/ws' });
+
+  wss.on('connection', (ws) => {
+    ws.on('error', (err) => console.error('WebSocket client error:', err.message));
+  });
+
+  console.log('WebSocket server attached at /ws');
+}
+
+/**
+ * Broadcast a notification to all connected browser dashboard clients.
+ * @param {import('./notificationStore').Notification} notification
+ */
+function broadcast(notification) {
+  if (!wss) return;
+  const message = JSON.stringify({ type: 'notification', data: notification });
+  wss.clients.forEach((client) => {
+    if (client.readyState === 1) client.send(message);
+  });
+}
+
+module.exports = { attachWebSocket, broadcast };


### PR DESCRIPTION
## Summary
- New `server/` directory — the central notification bridge that all platform PRs build into
- Express app with routes for webhooks (`/webhooks/*`), OAuth (`/auth/*`), and dashboard (`/dashboard/*`)
- All platform-specific routes are stubs returning `501` — filled in by AC3/4/5/6/7
- AWS IoT MQTT publisher — connects using the existing CDK-provisioned certificates, publishes batches to `weatherbox/notifications`, enforces the 6,000-byte Mega Serial buffer limit
- WebSocket server at `/ws` — broadcasts each accepted notification to browser dashboard clients in real time
- In-memory notification store — capped at 50 entries, 5-minute deduplication window, sorts by priority then recency
- Hot-reloadable rules engine — watches `rules.json` for changes so dashboard edits take effect immediately without a restart
- OAuth token store — persists platform tokens to `.tokens.json` (gitignored)

## Pi setup
`server/README.md` covers:
- Node.js install
- Cloudflare Tunnel for public HTTPS (free, no port forwarding)
- systemd service for auto-start on boot
- Step-by-step app registration guides for Slack, MS Teams, and Facebook Messenger

## Test plan
- [ ] `npm install && npm start` runs without errors
- [ ] `GET /health` returns `{"status":"ok"}`
- [ ] `GET /auth/status` returns `{slack: false, teams: false, messenger: false}`
- [ ] `GET /dashboard/rules` returns the default `rules.json` contents
- [ ] `POST /dashboard/rules` with a modified rules array persists to `rules.json`
- [ ] WebSocket connection to `/ws` stays open

## Depends on
- AC1 (message schema) should be reviewed first to confirm field names — this scaffold uses the same fields by convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)