### PR TITLE
AC5: Facebook Messenger webhook

### DIFF
--- a/server/src/routes/webhooks.js
+++ b/server/src/routes/webhooks.js
@@ -126,11 +126,73 @@ function verifyTeamsClientState(body) {
   return items.every((item) => !item.clientState || item.clientState === expectedState);
 }
 
-// ── Messenger (stub — filled in by AC7) ──────────────────────────────────────
+// ── Facebook Messenger ────────────────────────────────────────────────────────
+
+// Meta sends a GET request to verify the webhook URL before activating it
+router.get('/messenger', (req, res) => {
+  const mode = req.query['hub.mode'];
+  const token = req.query['hub.verify_token'];
+  const challenge = req.query['hub.challenge'];
+
+  if (mode === 'subscribe' && token === process.env.MESSENGER_VERIFY_TOKEN) {
+    return res.status(200).send(challenge);
+  }
+  res.sendStatus(403);
+});
 
 router.post('/messenger', (req, res) => {
-  res.status(501).json({ error: 'Messenger webhook not yet implemented' });
+  const body = req.body;
+  if (body.object !== 'page') return res.sendStatus(404);
+
+  for (const entry of body.entry ?? []) {
+    for (const event of entry.messaging ?? []) {
+      // Only handle inbound text messages (ignore echoes, reads, deliveries)
+      if (!event.message || event.message.is_echo) continue;
+
+      const senderId = event.sender?.id;
+      const text = event.message.text || '';
+      if (!text) continue;
+
+      const notification = {
+        id: `messenger-${event.message.mid || senderId + '-' + event.timestamp}`,
+        source: 'messenger',
+        sender: senderId || 'Unknown',
+        channel: senderId || 'Messenger',
+        preview: text.slice(0, 120),
+        timestamp: event.timestamp ? new Date(event.timestamp).toISOString() : new Date().toISOString(),
+        priority: 1,
+        metadata: {
+          platformMessageId: event.message.mid,
+          threadId: senderId,
+        },
+      };
+
+      // Resolve sender name asynchronously — update store entry if it changes
+      resolveSenderName(senderId).then((name) => {
+        if (name !== senderId) {
+          notification.sender = name;
+          notification.channel = name;
+        }
+        handleIncoming(notification);
+      }).catch(() => handleIncoming(notification));
+    }
+  }
+
+  // Meta requires a 200 response quickly to avoid retries
+  res.sendStatus(200);
 });
+
+async function resolveSenderName(psid) {
+  const token = require('../services/tokenStore').get('messenger')?.accessToken;
+  if (!token || !psid) return psid;
+  try {
+    const res = await fetch(`https://graph.facebook.com/v19.0/${psid}?fields=name&access_token=${token}`);
+    const data = await res.json();
+    return data.name || psid;
+  } catch {
+    return psid;
+  }
+}
 
 module.exports = router;
 module.exports.handleIncoming = handleIncoming;


### PR DESCRIPTION
## Summary
- `GET /webhooks/messenger` — handles Meta's hub verification handshake (required when registering the webhook in your Meta app)
- `POST /webhooks/messenger` — handles inbound message events, ignores echo/read/delivery events
- Resolves the sender's Facebook display name asynchronously via the Graph API so the TFT and feed UI show a real name instead of a raw PSID
- Responds with 200 immediately (before name resolution) to prevent Meta retry storms

## What it reads
All inbound text messages to the Facebook Page you connected via OAuth. Attachments (images, audio, etc.) are currently ignored — only text messages are forwarded.

## Test plan
- [ ] Complete Messenger OAuth at `/auth/messenger`
- [ ] In your Meta app, set Callback URL to `https://your-tunnel/webhooks/messenger`, paste `MESSENGER_VERIFY_TOKEN` — Meta verifies the endpoint (GET request)
- [ ] Send a Messenger message to your connected page — confirm it arrives at server and is forwarded via MQTT
- [ ] Confirm sender shows as display name, not a PSID number
- [ ] Send a non-text message (image) — confirm it is silently ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)