### PR TITLE
AC9: Mega TFT — notification feed display

### DIFF
--- a/mega_microcontroller_code/lib/LCD/LCD.cpp
+++ b/mega_microcontroller_code/lib/LCD/LCD.cpp
@@ -1,210 +1,190 @@
 #include "LCD.h"
 
-LCD::LCD()
-{
-}
+LCD::LCD() {}
 
 void LCD::startScreen()
 {
-    uint16_t ID = tft.readID(); // id of LCD Screen
-    if (ID == 0xD3D3)
-        ID = 0x9481; // write-only shield
+    uint16_t ID = tft.readID();
+    if (ID == 0xD3D3) ID = 0x9481; // write-only shield fallback
     tft.begin(ID);
 }
 
 void LCD::refreshScreen()
 {
-    tft.setRotation(1);
+    tft.setRotation(1); // landscape: 480×320
     tft.fillScreen(BLACK);
 }
 
+// ── Public entry point ────────────────────────────────────────────────────────
+
 void LCD::drawScreen(char *receivedChars)
 {
+    // Parse the notification batch: {"notifications":[...]}
+    // StaticJsonDocument keeps allocations on the stack (predictable on Mega).
+    // 3000 bytes handles up to ~5 notifications comfortably within 8KB SRAM.
+    StaticJsonDocument<3000> doc;
+    DeserializationError err = deserializeJson(doc, receivedChars);
 
-    Serial.println(receivedChars);
-    // convert receivedChars arduinojson
-    DynamicJsonDocument doc(700);
-    DeserializationError error = deserializeJson(doc, receivedChars);
-    Serial.print("doc.capacity ");
-    Serial.println(doc.capacity());
-
-    if (error)
+    if (err)
     {
-        Serial.print("deserializeJson() returned ");
-        Serial.println(error.c_str());
+        Serial.print("JSON parse error: ");
+        Serial.println(err.c_str());
         return;
     }
 
-    const char *dayOfWeek = doc["dayOfWeek"];
-    Serial.println(dayOfWeek);
-    const char *location = doc["location"];
-    Serial.println(location);
-    float temperature = doc["currently"]["temperature"];
-    Serial.println(temperature);
-    // set the box objects
-    LCDBoxCurrent boxCurrent(doc["location"], doc["currently"]["temperature"], doc["currently"]["humidity"], doc["currently"]["summary"]);
-
-    LCDBox box0(doc["dayOfWeek"], 0, doc["daily"]["data"][0]["temperatureLow"], doc["daily"]["data"][0]["temperatureHigh"], doc["daily"]["data"][0]["humidity"], doc["daily"]["data"][0]["summary"]);
-
-    LCDBox box1(doc["dayOfWeek"], 1, doc["daily"]["data"][1]["temperatureLow"], doc["daily"]["data"][1]["temperatureHigh"], doc["daily"]["data"][1]["humidity"], doc["daily"]["data"][1]["summary"]);
-
-    LCDBox box2(doc["dayOfWeek"], 2, doc["daily"]["data"][2]["temperatureLow"], doc["daily"]["data"][2]["temperatureHigh"], doc["daily"]["data"][2]["humidity"], doc["daily"]["data"][2]["summary"]);
-
-    LCDBox box3(doc["dayOfWeek"], 3, doc["daily"]["data"][3]["temperatureLow"], doc["daily"]["data"][3]["temperatureHigh"], doc["daily"]["data"][3]["humidity"], doc["daily"]["data"][3]["summary"]);
-
-    LCDBox box4(doc["dayOfWeek"], 4, doc["daily"]["data"][4]["temperatureLow"], doc["daily"]["data"][4]["temperatureHigh"], doc["daily"]["data"][4]["humidity"], doc["daily"]["data"][4]["summary"]);
-
-    LCDBox box5(doc["dayOfWeek"], 5, doc["daily"]["data"][5]["temperatureLow"], doc["daily"]["data"][5]["temperatureHigh"], doc["daily"]["data"][5]["humidity"], doc["daily"]["data"][5]["summary"]);
-
-    LCDBox box6(doc["dayOfWeek"], 6, doc["daily"]["data"][6]["temperatureLow"], doc["daily"]["data"][6]["temperatureHigh"], doc["daily"]["data"][6]["humidity"], doc["daily"]["data"][6]["summary"]);
-
-    // drawing has to take place from left to right so that
-    // any overwriting cuts things off
-    drawCurrentBox(boxCurrent);
-    drawBox(box0, 120, 6, '0');
-    Serial.println(box0.tempMin);
-    drawBox(box1, 240, 6, '1');
-    drawBox(box2, 360, 6, '2');
-
-    drawBox(box3, 6, 160, '3');
-    drawBox(box4, 120, 160, '4');
-    drawBox(box5, 240, 160, '5');
-    drawBox(box6, 360, 160, '6');
-}
-
-void LCD::drawCurrentBox(LCDBoxCurrent box)
-{
-    int currentX = 6;
-    int currentY = 6;
-    currentY = printmsg(currentX, currentY, 1, WHITE, "Current");
-    currentY = printmsg(currentX, currentY, 2, YELLOW, box.weatherMain);
-    char tempBuff[10]; // create memory buffs outside for inside scope access
-    floatToCharArr(box.temp, tempBuff);
-    strcat(tempBuff, "C");
-    currentY = printmsg(currentX, currentY, 2, WHITE, tempBuff);
-
-    char humBuff[10]; // create memory buffs outside for inside scope access
-    floatToCharArr(box.humidity, humBuff);
-    currentY = printmsg(currentX, currentY, 2, WHITE, humBuff);
-    currentY = printmsg(currentX, currentY, 2, GREEN, box.location);
-}
-
-void LCD::drawBox(LCDBox box, int x, int y, char day)
-{
-    int currentY = y;
-    char dayVal[10];
-    if (day == '0')
+    JsonArray notifications = doc["notifications"].as<JsonArray>();
+    if (notifications.isNull())
     {
-        strcpy(dayVal, "Today");
+        Serial.println("No notifications array in payload");
+        return;
     }
-    else if (day == '1')
+
+    refreshScreen();
+    drawHeader();
+
+    uint8_t row = 0;
+    for (JsonObject n : notifications)
     {
-        strcpy(dayVal, "Tomorrow");
-    }
-    else
-    {
-        strcpy(dayVal, box.dayOfWeek);
-        char dayStr[2] = {'\0'};
-        strcat(dayVal, dayStr);
-    }
-    Serial.println(currentY);
-    Serial.println(dayVal);
-    Serial.println(box.tempMin);
-    Serial.println(box.tempMax);
-    Serial.println(box.humidity);
-    Serial.println(box.weatherMain);
-    currentY = printmsg(x, currentY, 1, WHITE, dayVal);
-    currentY = printmsg(x, currentY, 2, YELLOW, box.weatherMain);
+        if (row >= MAX_ROWS) break;
 
-    char tempMinBuff[10]; // create memory buffs outside for inside scope access
-    floatToCharArr(box.tempMin, tempMinBuff);
-    char tempMaxBuff[10];
-    floatToCharArr(box.tempMax, tempMaxBuff);
+        const char *source    = n["source"]    | "?";
+        const char *sender    = n["sender"]    | "";
+        const char *channel   = n["channel"]   | "";
+        const char *preview   = n["preview"]   | "";
+        const char *timestamp = n["timestamp"] | "";
+        uint8_t priority      = n["priority"]  | 1;
 
-    // concat tempMin and tempMax
-    char tempBuff[20];
-    strcpy(tempBuff, tempMinBuff);
-    strcat(tempBuff, " - ");
-    strcat(tempBuff, tempMaxBuff);
-    strcat(tempBuff, "C");
-    currentY = printmsg(x, currentY, 2, WHITE, tempBuff);
-
-    char humBuff[5];
-    floatToCharArr(box.humidity, humBuff);
-    currentY = printmsg(x, currentY, 2, WHITE, humBuff);
-}
-
-void LCD::floatToCharArr(float value, char *buff)
-{
-    int val_int = (int)value;                     // compute the integer part of the float
-    int val_fra = (int)((value - val_int) * 100); // compute 2 decimal places (and convert it to int)
-    sprintf(buff, "%d.%02d", val_int, val_fra);   // create a string with the 'floated' value including preceding 0s
-}
-
-// returns the new y location (including padding of 2) factoring in the textSize
-int LCD::printmsg(int x, int y, int textSize, int color, const char *msg)
-{
-    // split across multiple rows if too long
-    // calculate width of added tokens
-    // if longer than MAX_WINDOW_WIDTH
-    // start new line
-    const char *delimiter = " ";
-    char *token;
-    char testMsg[50]; // can use malloc but not working
-
-    strncpy(testMsg, msg, sizeof(testMsg));
-    token = strtok(testMsg, delimiter);
-    int tokenWidth = strlen(token) * DEFAULT_SCREEN_CHARACTER_X_WIDTH * textSize;
-
-    if (tokenWidth > MAX_WINDOW_WIDTH)
-    {
-        textSize = 1; // set textSize to smallest value
-    }
-    // for second + tokens
-    while (token != NULL)
-    {
-        token = strtok(NULL, delimiter);
-        tokenWidth = strlen(token) * DEFAULT_SCREEN_CHARACTER_X_WIDTH * textSize; // recalculate token width
-        // see if any tokens are wider than MAX_WINDOW_WIDTH
-        if (tokenWidth > MAX_WINDOW_WIDTH)
+        // Extract HH:MM from ISO8601 timestamp (chars 11-15)
+        char timeStr[6] = "--:--";
+        if (strlen(timestamp) >= 16)
         {
-            textSize = 1; // set textSize to smallest value
+            timeStr[0] = timestamp[11];
+            timeStr[1] = timestamp[12];
+            timeStr[2] = ':';
+            timeStr[3] = timestamp[14];
+            timeStr[4] = timestamp[15];
+            timeStr[5] = '\0';
         }
+
+        drawRow(row, source, sender, channel, preview, timeStr, priority);
+        row++;
     }
 
-    tft.setTextColor(color, BLACK);
-    tft.setTextSize(textSize); // default 6*8 (x,y)
-    tft.setCursor(x, y);
-    // Tokenise actual msg
-    token = strtok(msg, delimiter);
-    tokenWidth = (strlen(token) + 1) * DEFAULT_SCREEN_CHARACTER_X_WIDTH * textSize; // reuse tokenWidth
-    tft.println(token);
-    int xPos = x + tokenWidth;
-    tft.setCursor(xPos, y); // move to right
+    if (row == 0) drawIdleScreen();
 
-    int lineWidth = tokenWidth; // calculate current point in line;
-
-    // loop through rest of tokens
-    while (token != NULL)
-    {
-        token = strtok(NULL, delimiter);
-        tokenWidth = (strlen(token) + 1) * DEFAULT_SCREEN_CHARACTER_X_WIDTH * textSize; // reuse tokenWidth
-        lineWidth = lineWidth + tokenWidth;                                             // calculate current point in line
-
-        if (lineWidth > MAX_WINDOW_WIDTH)
-        {
-            xPos = x;                       // set x position to be start
-            y = 8 * textSize + PADDING + y; // set new line
-            lineWidth = tokenWidth;
-        }
-        tft.setCursor(xPos, y); // include space at end
-        tft.println(token);
-        xPos = xPos + (strlen(token) + 1) * DEFAULT_SCREEN_CHARACTER_X_WIDTH * textSize; // reset new xPos
-    }
-
-    return DEFAULT_SCREEN_CHARACTER_X_HEIGHT * textSize + PADDING + y;
+    lastDataMs = millis();
+    isIdle = false;
 }
 
-LCD::~LCD()
+// Called from loop() to show idle screen after IDLE_TIMEOUT_MS with no data
+void LCD::checkIdle()
 {
+    if (!isIdle && millis() - lastDataMs > IDLE_TIMEOUT_MS)
+    {
+        refreshScreen();
+        drawIdleScreen();
+        isIdle = true;
+    }
 }
+
+// ── Private drawing helpers ───────────────────────────────────────────────────
+
+void LCD::drawHeader()
+{
+    tft.setTextColor(DARKGREY, BLACK);
+    tft.setTextSize(1);
+    tft.setCursor(4, 6);
+    tft.print("WEATHERBOX NOTIFICATIONS");
+    // horizontal divider under header
+    tft.drawFastHLine(0, HEADER_H, SCREEN_W, DARKGREY);
+}
+
+void LCD::drawRow(int rowIndex, const char *source, const char *sender,
+                  const char *channel, const char *preview,
+                  const char *timeStr, uint8_t priority)
+{
+    int y = HEADER_H + rowIndex * ROW_H;
+
+    // Row border — yellow for priority 3, dark grey otherwise
+    uint16_t borderColor = (priority >= 3) ? YELLOW : DARKGREY;
+    tft.drawRect(0, y + 1, SCREEN_W, ROW_H - 2, borderColor);
+
+    uint16_t badgeColor = sourceColor(source);
+
+    // ── Source badge (top-left) ───────────────────────────────────────────────
+    // Draw a filled rounded rect behind the source label
+    char srcUpper[8];
+    truncate(source, srcUpper, 7);
+    for (uint8_t i = 0; srcUpper[i]; i++)
+        if (srcUpper[i] >= 'a' && srcUpper[i] <= 'z') srcUpper[i] -= 32;
+    // Shorten "MESSENGER" → "MSG"
+    if (strncmp(srcUpper, "MESSENG", 7) == 0) strcpy(srcUpper, "MSG");
+
+    int badgeW = strlen(srcUpper) * 6 + 6; // textSize=1: 6px/char
+    tft.fillRoundRect(ROW_PAD, y + ROW_PAD, badgeW, 14, 3, badgeColor);
+    tft.setTextColor(BLACK, badgeColor);
+    tft.setTextSize(1);
+    tft.setCursor(ROW_PAD + 3, y + ROW_PAD + 3);
+    tft.print(srcUpper);
+
+    // ── Channel name (next to badge) ──────────────────────────────────────────
+    char chanBuf[33];
+    truncate(channel, chanBuf, 32);
+    tft.setTextColor(WHITE, BLACK);
+    tft.setTextSize(1);
+    tft.setCursor(ROW_PAD + badgeW + 6, y + ROW_PAD + 3);
+    tft.print(chanBuf);
+
+    // ── Timestamp (top-right) ─────────────────────────────────────────────────
+    int timeX = SCREEN_W - strlen(timeStr) * 6 - ROW_PAD;
+    tft.setTextColor(DARKGREY, BLACK);
+    tft.setTextSize(1);
+    tft.setCursor(timeX, y + ROW_PAD + 3);
+    tft.print(timeStr);
+
+    // ── Sender (middle line, larger text) ────────────────────────────────────
+    char senderBuf[22];
+    truncate(sender, senderBuf, 21); // textSize=2: 12px/char, max ~38 chars on 480px
+    tft.setTextColor(badgeColor, BLACK);
+    tft.setTextSize(2);
+    tft.setCursor(ROW_PAD, y + ROW_PAD + 18);
+    tft.print(senderBuf);
+
+    // ── Preview text (bottom line) ────────────────────────────────────────────
+    char previewBuf[73];
+    truncate(preview, previewBuf, 72); // textSize=1: up to 80 chars on 480px
+    tft.setTextColor(WHITE, BLACK);
+    tft.setTextSize(1);
+    tft.setCursor(ROW_PAD, y + ROW_PAD + 38);
+    tft.print(previewBuf);
+
+    // Row divider
+    tft.drawFastHLine(0, y + ROW_H - 1, SCREEN_W, DARKGREY);
+}
+
+void LCD::drawIdleScreen()
+{
+    tft.setTextColor(DARKGREY, BLACK);
+    tft.setTextSize(2);
+    int msgLen = 22 * 12; // "No new notifications" × 12px/char
+    tft.setCursor((SCREEN_W - msgLen) / 2, SCREEN_H / 2 - 8);
+    tft.print("No new notifications");
+}
+
+uint16_t LCD::sourceColor(const char *source)
+{
+    if (strncmp(source, "slack",     5) == 0) return MAGENTA;
+    if (strncmp(source, "teams",     5) == 0) return BLUE;
+    if (strncmp(source, "messenger", 9) == 0) return CYAN;
+    if (strncmp(source, "iot",       3) == 0) return ORANGE;
+    return WHITE;
+}
+
+void LCD::truncate(const char *src, char *dst, uint8_t maxLen)
+{
+    if (!src) { dst[0] = '\0'; return; }
+    strncpy(dst, src, maxLen);
+    dst[maxLen] = '\0';
+}
+
+LCD::~LCD() {}

--- a/mega_microcontroller_code/lib/LCD/LCD.h
+++ b/mega_microcontroller_code/lib/LCD/LCD.h
@@ -1,9 +1,6 @@
 #ifndef LCD_H
 #define LCD_H
 
-#include <LCDBox.h>
-#include <LCDBoxCurrent.h>
-
 #include <Adafruit_I2CDevice.h>
 #include <SPI.h>
 #include "Adafruit_GFX.h"
@@ -11,30 +8,42 @@
 #include <MCUFRIEND_kbv.h>
 #include <stdio.h>
 
-// Assign human-readable names to some common 16-bit color values:
-#define BLACK 0x0000
-#define BLUE 0x001F
-#define RED 0xF800
-#define GREEN 0x07E0
-#define CYAN 0x07FF
-#define MAGENTA 0xF81F
-#define YELLOW 0xFFE0
-#define WHITE 0xFFFF
+// 16-bit colour values (5-6-5 RGB)
+#define BLACK    0x0000
+#define WHITE    0xFFFF
+#define YELLOW   0xFFE0
+#define CYAN     0x07FF
+#define MAGENTA  0xF81F
+#define BLUE     0x001F
+#define GREEN    0x07E0
+#define ORANGE   0xFD20
+#define DARKGREY 0x4208
 
-#define MAX_WINDOW_WIDTH 120
-#define MAX_WINDOW_HEIGHT 160
-#define PADDING 4
-#define DEFAULT_SCREEN_CHARACTER_X_WIDTH 6
-#define DEFAULT_SCREEN_CHARACTER_X_HEIGHT 6
+// Screen layout (landscape 480×320)
+#define SCREEN_W  480
+#define SCREEN_H  320
+#define HEADER_H   20
+#define ROW_H      60
+#define MAX_ROWS    5
+#define ROW_PAD     4
+
+// Idle timeout: redraw idle screen if no data for this many ms
+#define IDLE_TIMEOUT_MS 300000UL  // 5 minutes
 
 class LCD
 {
 private:
     MCUFRIEND_kbv tft;
-    void drawBox(LCDBox box, int x, int y, char day);
-    void drawCurrentBox(LCDBoxCurrent box);
-    void floatToCharArr(float value, char *buff);
-    int printmsg(int x, int y, int textSize, int color, const char *msg);
+    unsigned long lastDataMs = 0;
+    bool isIdle = false;
+
+    void drawHeader();
+    void drawRow(int rowIndex, const char *source, const char *sender,
+                 const char *channel, const char *preview,
+                 const char *timeStr, uint8_t priority);
+    void drawIdleScreen();
+    uint16_t sourceColor(const char *source);
+    void truncate(const char *src, char *dst, uint8_t maxLen);
 
 public:
     LCD();
@@ -42,6 +51,7 @@ public:
     void startScreen();
     void refreshScreen();
     void drawScreen(char *receivedChars);
+    void checkIdle();
 };
 
 #endif

--- a/mega_microcontroller_code/src/main.cpp
+++ b/mega_microcontroller_code/src/main.cpp
@@ -7,7 +7,6 @@ LCD myLCD;
 
 void setup()
 {
-  // put your setup code here, to run once:
   Serial.begin(115200);
   myLCD.startScreen();
   myLCD.refreshScreen();
@@ -15,14 +14,14 @@ void setup()
 
 void loop()
 {
-  // put your main code here, to run repeatedly:
   bool newData = myCommunication.receiveData();
-  // print screen only if new data is received
   if (newData)
   {
-    Serial.println("Received new data");
-    myLCD.refreshScreen(); // refresh screen
+    Serial.println("Received notification batch");
     myLCD.drawScreen(myCommunication.getReceivedChars());
     myCommunication.setNewData(false);
   }
+
+  // Show idle screen after 5 minutes without new notifications
+  myLCD.checkIdle();
 }


### PR DESCRIPTION
## Summary
Replaces the 2×4 weather grid with a vertically stacked notification feed.

**Layout (480×320 landscape)**
```
┌──────────────────────────────────────────────────┐
│  WEATHERBOX NOTIFICATIONS                        │  20px header
├──────────────────────────────────────────────────┤
│ [SLACK] #alerts                          14:30   │  60px row
│ jackylui  (magenta)                              │
│ Deploy to production is live ✓                   │
├──────────────────────────────────────────────────┤
│ [TEAMS] General                          14:15   │  yellow border = priority 3
│ Bob Smith  (blue)                                │
│ Standup moved to 3pm today                       │
├──────────────────────────────────────────────────┤
│ [MSG] John Doe                           13:50   │
│ John Doe  (cyan)                                 │
│ Hey are you free tonight?                        │
└──────────────────────────────────────────────────┘
```

**Row anatomy**
- Source badge: filled rounded rect, colour-coded (Slack=magenta, Teams=blue, Messenger=cyan, IoT=orange)
- Channel name + HH:MM timestamp on the first line
- Sender name in source colour at 2× text size
- Preview text at 1× size, truncated to 72 chars
- Yellow border for priority 3, dark grey otherwise

**Idle screen**: after 5 minutes without new data, displays "No new notifications" centred

**Memory**: uses `StaticJsonDocument<3000>` (stack-allocated) to stay within the Mega's 8KB SRAM budget

## Test plan
- [ ] Flash to Mega, confirm screen clears and header "WEATHERBOX NOTIFICATIONS" appears
- [ ] Send a test notification batch over Serial (paste a `{"notifications":[...]}` JSON) — rows render correctly
- [ ] Priority-3 notification has a yellow border
- [ ] Wait 5 minutes with no new data — idle screen appears
- [ ] Send a new batch — idle screen clears, new rows render
- [ ] >5 notifications in batch — only first 5 shown, no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)