### PR TITLE
Add weather poller to Express server for pipeline testing

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -41,6 +41,17 @@ MESSENGER_VERIFY_TOKEN=choose-any-random-string-here
 # Redirect URI registered in your Meta app
 MESSENGER_REDIRECT_URI=https://your-tunnel.trycloudflare.com/auth/messenger/callback
 
+# ── Weather poller ────────────────────────────────────────────────────────────
+# PirateWeather API key — same key used in config_upload/src/example_config.h
+WEATHER_API_KEY=
+# Optional: fixed coordinates — skips the ipapi.co geolocation call each hour
+# Leave blank to auto-detect location by IP
+WEATHER_LAT=
+WEATHER_LON=
+WEATHER_CITY=
+# How often to fetch weather and push to the display (milliseconds, default 1 hour)
+WEATHER_POLL_INTERVAL_MS=3600000
+
 # ── Session ────────────────────────────────────────────────────────────────────
 # Any long random string — used to sign the OAuth state parameter
 SESSION_SECRET=change-me-to-something-random

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -4,6 +4,7 @@ const path = require('path');
 const webhookRoutes = require('./routes/webhooks');
 const authRoutes = require('./routes/auth');
 const dashboardRoutes = require('./routes/dashboard');
+const weatherRoutes = require('./routes/weather');
 
 const app = express();
 
@@ -14,6 +15,7 @@ app.use(express.static(path.join(__dirname, '../public')));
 app.use('/webhooks', webhookRoutes);
 app.use('/auth', authRoutes);
 app.use('/dashboard', dashboardRoutes);
+app.use('/weather', weatherRoutes);
 
 app.get('/health', (_req, res) => res.json({ status: 'ok' }));
 

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -5,6 +5,7 @@ const { initMqtt } = require('./services/mqtt');
 const { attachWebSocket } = require('./services/websocket');
 const tokenStore = require('./services/tokenStore');
 const teamsSubscription = require('./services/teamsSubscription');
+const weatherPoller = require('./services/weatherPoller');
 
 const PORT = process.env.PORT || 3000;
 
@@ -25,3 +26,9 @@ httpServer.listen(PORT, async () => {
 });
 
 initMqtt();
+
+if (process.env.WEATHER_API_KEY) {
+  weatherPoller.start();
+} else {
+  console.log('WEATHER_API_KEY not set — weather poller disabled. Set it in .env to enable.');
+}

--- a/server/src/routes/weather.js
+++ b/server/src/routes/weather.js
@@ -1,0 +1,17 @@
+const { Router } = require('express');
+const { fetchWeather } = require('../services/weatherPoller');
+
+const router = Router();
+
+// Manual trigger — useful for testing the full pipeline without waiting an hour.
+// Returns the notification that was published so you can inspect the format.
+router.post('/fetch', async (_req, res) => {
+  try {
+    const notification = await fetchWeather();
+    res.json({ ok: true, published: notification });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/src/services/weatherPoller.js
+++ b/server/src/services/weatherPoller.js
@@ -1,0 +1,82 @@
+const { publishBatch } = require('./mqtt');
+
+const PIRATE_WEATHER_BASE = 'https://api.pirateweather.net/forecast';
+const IPAPI_URL = 'https://ipapi.co/json/';
+
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+let intervalId = null;
+
+// ── Location ──────────────────────────────────────────────────────────────────
+
+async function getLocation() {
+  // Use fixed coords from env if provided — avoids a network call every hour
+  const lat = parseFloat(process.env.WEATHER_LAT);
+  const lon = parseFloat(process.env.WEATHER_LON);
+  if (!isNaN(lat) && !isNaN(lon)) {
+    return { lat, lon, city: process.env.WEATHER_CITY || 'Home' };
+  }
+
+  const res = await fetch(IPAPI_URL);
+  if (!res.ok) throw new Error(`ipapi.co returned ${res.status}`);
+  const data = await res.json();
+  return { lat: data.latitude, lon: data.longitude, city: data.city || 'Unknown' };
+}
+
+// ── Weather fetch ─────────────────────────────────────────────────────────────
+
+async function fetchWeather() {
+  const apiKey = process.env.WEATHER_API_KEY;
+  if (!apiKey) throw new Error('WEATHER_API_KEY not set in .env');
+
+  const { lat, lon, city } = await getLocation();
+
+  const url = `${PIRATE_WEATHER_BASE}/${apiKey}/${lat},${lon}?units=ca&exclude=minutely,hourly,alerts`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`PirateWeather returned ${res.status}`);
+  const data = await res.json();
+
+  const current = data.currently;
+  const temp = Math.round(current.temperature ?? 0);
+  const humidity = Math.round((current.humidity ?? 0) * 100);
+  const summary = current.summary || 'Unknown';
+
+  const dayName = DAY_NAMES[new Date().getDay()];
+  const channel = `${city} · ${dayName}`;
+  const preview = `${temp}°C · ${summary} · Humidity ${humidity}%`;
+
+  const notification = {
+    id: `iot-weather-${Math.floor(Date.now() / 1000)}`,
+    source: 'iot',
+    sender: 'Weather',
+    channel: channel.slice(0, 32),
+    preview: preview.slice(0, 120),
+    timestamp: new Date().toISOString(),
+    priority: 1,
+    metadata: { platformMessageId: String(Date.now()) },
+  };
+
+  publishBatch([notification]);
+  console.log(`Weather published: ${preview}`);
+  return notification;
+}
+
+// ── Scheduler ─────────────────────────────────────────────────────────────────
+
+function start() {
+  const intervalMs = parseInt(process.env.WEATHER_POLL_INTERVAL_MS, 10) || 60 * 60 * 1000;
+
+  // Fetch immediately on start, then on the interval
+  fetchWeather().catch((err) => console.error('Weather fetch failed:', err.message));
+  intervalId = setInterval(() => {
+    fetchWeather().catch((err) => console.error('Weather fetch failed:', err.message));
+  }, intervalMs);
+
+  console.log(`Weather poller started — interval ${intervalMs / 1000}s`);
+}
+
+function stop() {
+  if (intervalId) { clearInterval(intervalId); intervalId = null; }
+}
+
+module.exports = { start, stop, fetchWeather };


### PR DESCRIPTION
## Summary
Moves weather fetching from the ESP32 into the Express server so the full MQTT → Serial → TFT pipeline can be tested without connecting Slack, Teams, or Messenger.

**New files**
- `server/src/services/weatherPoller.js` — fetches PirateWeather every hour, converts to a unified notification, publishes to `weatherbox/notifications` via MQTT
- `server/src/routes/weather.js` — `POST /weather/fetch` for an immediate on-demand fetch

**How it works**
1. On server start (if `WEATHER_API_KEY` is set), the poller fetches immediately then repeats on the configured interval
2. Location: uses `WEATHER_LAT`/`WEATHER_LON` from `.env` if set, otherwise calls `ipapi.co` to geolocate by IP
3. Publishes one `source: "iot"` notification — shows as an orange `[IOT]` row on the Mega

**Display output**
```
[IOT] Sydney · Monday               10:30
Weather
22°C · Partly Cloudy · Humidity 65%
```

## Test plan
- [ ] Set `WEATHER_API_KEY` in `.env`, run `npm start` — "Weather poller started" and "Weather published: ..." logs appear on boot
- [ ] `POST /weather/fetch` returns `{ ok: true, published: { source: "iot", ... } }`
- [ ] With ESP32 + Mega connected, `POST /weather/fetch` — Mega display updates within a few seconds
- [ ] Leave `WEATHER_API_KEY` unset — server starts cleanly with "weather poller disabled" log, no errors
- [ ] Set `WEATHER_LAT`/`WEATHER_LON` — confirm ipapi.co is not called (check network logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)