### PR TITLE
Mega polls ESP32 for cached notifications on idle

### DIFF
--- a/esp32_microcontroller_code/src/main.cpp
+++ b/esp32_microcontroller_code/src/main.cpp
@@ -23,11 +23,15 @@ MegaCommunication megaCommunication;
 IntervalFetcher heartbeatTimer = IntervalFetcher(HEARTBEAT_INTERVAL_MS);
 WiFiProvisioner provisioner;
 
+// Last notification batch received — re-sent to Mega on poll request
+String lastBatch = "";
+
 // ── MQTT message handler ──────────────────────────────────────────────────────
 
 void messageHandler(String &topic, String &payload)
 {
   if (topic != NOTIFICATIONS_SUBSCRIBE_TOPIC) return;
+  lastBatch = payload;
   megaCommunication.sendRaw(payload.c_str());
 }
 
@@ -137,6 +141,13 @@ void loop()
   {
     Serial.println("MQTT disconnected — reconnecting");
     connectAWS();
+  }
+
+  // Respond to poll requests from the Mega ('P' byte sent when its idle timeout fires)
+  if (Serial1.available() && Serial1.read() == 'P' && lastBatch.length() > 0)
+  {
+    Serial.println("Poll request received — re-sending last batch");
+    megaCommunication.sendRaw(lastBatch.c_str());
   }
 
   if (heartbeatTimer.shouldFetch())

--- a/mega_microcontroller_code/lib/Communication/Communication.cpp
+++ b/mega_microcontroller_code/lib/Communication/Communication.cpp
@@ -53,6 +53,12 @@ void Communication::setNewData(bool newDataFlag){
   newData = newDataFlag;
 }
 
+// Sends a single poll byte to the ESP32, asking it to re-send its last batch.
+void Communication::sendPollRequest()
+{
+  Serial1.write('P');
+}
+
 Communication::~Communication()
 {
 }

--- a/mega_microcontroller_code/lib/Communication/Communication.h
+++ b/mega_microcontroller_code/lib/Communication/Communication.h
@@ -16,6 +16,7 @@ public:
     bool receiveData();
     char * getReceivedChars();
     void setNewData(bool newDataFlag);
+    void sendPollRequest();
 };
 
 #endif

--- a/mega_microcontroller_code/lib/LCD/LCD.cpp
+++ b/mega_microcontroller_code/lib/LCD/LCD.cpp
@@ -70,21 +70,22 @@ void LCD::drawScreen(char *receivedChars)
         row++;
     }
 
-    if (row == 0) drawIdleScreen();
-
     lastDataMs = millis();
-    isIdle = false;
+    _idle = false;
+    _pollSent = false;
 }
 
-// Called from loop() to show idle screen after IDLE_TIMEOUT_MS with no data
-void LCD::checkIdle()
+// Returns true once when the idle timeout first fires — caller sends a poll request.
+// Resets automatically when drawScreen() is called with new data.
+bool LCD::checkIdle()
 {
-    if (!isIdle && millis() - lastDataMs > IDLE_TIMEOUT_MS)
+    if (!_pollSent && millis() - lastDataMs > IDLE_TIMEOUT_MS)
     {
-        refreshScreen();
-        drawIdleScreen();
-        isIdle = true;
+        _idle = true;
+        _pollSent = true;
+        return true;
     }
+    return false;
 }
 
 // ── Private drawing helpers ───────────────────────────────────────────────────
@@ -162,14 +163,6 @@ void LCD::drawRow(int rowIndex, const char *source, const char *sender,
     tft.drawFastHLine(0, y + ROW_H - 1, SCREEN_W, DARKGREY);
 }
 
-void LCD::drawIdleScreen()
-{
-    tft.setTextColor(DARKGREY, BLACK);
-    tft.setTextSize(2);
-    int msgLen = 22 * 12; // "No new notifications" × 12px/char
-    tft.setCursor((SCREEN_W - msgLen) / 2, SCREEN_H / 2 - 8);
-    tft.print("No new notifications");
-}
 
 uint16_t LCD::sourceColor(const char *source)
 {

--- a/mega_microcontroller_code/lib/LCD/LCD.h
+++ b/mega_microcontroller_code/lib/LCD/LCD.h
@@ -35,13 +35,13 @@ class LCD
 private:
     MCUFRIEND_kbv tft;
     unsigned long lastDataMs = 0;
-    bool isIdle = false;
+    bool _idle = false;
+    bool _pollSent = false;
 
     void drawHeader();
     void drawRow(int rowIndex, const char *source, const char *sender,
                  const char *channel, const char *preview,
                  const char *timeStr, uint8_t priority);
-    void drawIdleScreen();
     uint16_t sourceColor(const char *source);
     void truncate(const char *src, char *dst, uint8_t maxLen);
 
@@ -51,7 +51,8 @@ public:
     void startScreen();
     void refreshScreen();
     void drawScreen(char *receivedChars);
-    void checkIdle();
+    // Returns true once when idle timeout first fires — caller should send a poll request.
+    bool checkIdle();
 };
 
 #endif

--- a/mega_microcontroller_code/src/main.cpp
+++ b/mega_microcontroller_code/src/main.cpp
@@ -22,6 +22,10 @@ void loop()
     myCommunication.setNewData(false);
   }
 
-  // Show idle screen after 5 minutes without new notifications
-  myLCD.checkIdle();
+  // After 5 minutes with no new data, ask the ESP32 to re-send its last batch
+  if (myLCD.checkIdle())
+  {
+    Serial.println("Idle timeout — polling ESP32 for last batch");
+    myCommunication.sendPollRequest();
+  }
 }


### PR DESCRIPTION
## Summary
Replaces the 5-minute idle screen with an on-demand poll. When the idle timeout fires, the Mega sends a single `'P'` byte to the ESP32 over Serial1. The ESP32 caches its last received MQTT batch and re-sends it — the display always shows real notifications.

## Changes
- **ESP32 `main.cpp`**: adds `String lastBatch` global, populated in `messageHandler()`. `loop()` checks `Serial1.available()` for `'P'` and re-sends `lastBatch` when received.
- **Mega `Communication`**: adds `sendPollRequest()` — writes `'P'` to Serial1
- **Mega `LCD`**: `checkIdle()` now returns `bool`, fires `true` only once per idle cycle (not every 100ms loop). Removed `drawIdleScreen()` entirely.
- **Mega `main.cpp`**: calls `sendPollRequest()` when `checkIdle()` returns true

## Memory
`String lastBatch` on ESP32 holds up to ~6KB. ESP32 has 177KB free heap — negligible cost.

## Test plan
- [ ] Flash both boards
- [ ] Trigger `POST /weather/fetch` — weather row appears on TFT
- [ ] Wait 5+ minutes — display stays showing weather (no idle screen, poll fires instead)
- [ ] Serial log on ESP32 shows "Poll request received — re-sending last batch"
- [ ] Trigger another push — display updates normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)